### PR TITLE
fix: disconnect socket when leaving room

### DIFF
--- a/apps/web/components/provider/SocketProvider.tsx
+++ b/apps/web/components/provider/SocketProvider.tsx
@@ -8,39 +8,46 @@ import {
   User,
 } from "../../types/aliases";
 import { io, Socket } from "socket.io-client";
-import React, { createContext, useEffect, useState } from "react";
+import React, {
+  createContext,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState,
+} from "react";
 import { useRouter } from "next/router";
-import axios from "axios";
 
 type Values = {
   average: Average;
-  roomStatus: Status;
-  serverReady: boolean;
-  user: User | undefined;
-  users: User[];
   changeStatus: (status: string) => void;
   disconnect: () => void;
   estimate: (estimate: number) => void;
+  estimateOptions: PossibleEstimates;
   removeUser: () => void;
   reset: () => void;
-  userJoin: (name: string, room: string) => void;
-  estimateOptions: PossibleEstimates;
+  roomStatus: Status;
+  setRoomId: Dispatch<SetStateAction<string>>;
+  serverReady: boolean;
   updateRoomOptions: (args: RoomOptions) => void;
+  user: User | undefined;
+  userJoin: (name: string, room: string) => void;
+  users: User[];
 };
 const initalValues: Values = {
   average: null,
-  roomStatus: "estimating",
-  serverReady: false,
-  user: undefined,
-  users: [],
-  estimateOptions: [],
-  updateRoomOptions: () => undefined,
   changeStatus: () => undefined,
   disconnect: () => undefined,
   estimate: () => undefined,
+  estimateOptions: [],
   removeUser: () => undefined,
   reset: () => undefined,
+  roomStatus: "estimating",
+  serverReady: false,
+  setRoomId: () => undefined,
+  updateRoomOptions: () => undefined,
+  user: undefined,
   userJoin: () => undefined,
+  users: [],
 };
 
 export const SocketContext = createContext<Values>(initalValues);
@@ -60,9 +67,12 @@ export default function AppProvider({ children }: Props) {
   const [status, setStatus] = useState<Status>("estimating");
   const [user, setUser] = useState<User>();
   const [users, setUsers] = useState<User[]>([]);
+  const [roomId, setRoomId] = useState<string>();
 
   useEffect(() => {
-    if (!serverReady) return;
+    if (!roomId) {
+      return;
+    }
     const newSocket = io(`${process.env.NEXT_PUBLIC_SERVER}`);
     newSocket.on("connect_error", (err) => console.warn("err", err));
 
@@ -91,7 +101,7 @@ export default function AppProvider({ children }: Props) {
     return () => {
       newSocket.disconnect();
     };
-  }, [serverReady]);
+  }, [roomId]);
 
   const changeStatus = (status: Status) => {
     socket.emit("changeStatus", { status });
@@ -104,6 +114,7 @@ export default function AppProvider({ children }: Props) {
   };
   const removeUser = () => {
     socket.emit("removeUser");
+    setRoomId(null);
   };
 
   const updateRoomOptions = (options: RoomOptions) => {
@@ -118,53 +129,23 @@ export default function AppProvider({ children }: Props) {
     socket.emit("userJoin", { name, room });
   };
 
-  const checkHealth = async () => {
-    const healthUrl = `${process.env.NEXT_PUBLIC_SERVER}/health`;
-    try {
-      await axios.get(healthUrl);
-      setServerReady(true);
-      return null;
-    } catch (error) {
-      let tries = 5;
-      const interval = setInterval(async () => {
-        try {
-          await axios.get(healthUrl);
-          setServerReady(true);
-          clearInterval(interval);
-        } catch (error) {
-          console.log("error", error);
-        }
-        tries -= 1;
-        if (tries < 1) clearInterval(interval);
-      }, 2000);
-      return interval;
-    }
-  };
-
-  useEffect(() => {
-    const interval = checkHealth();
-
-    return () => {
-      interval.then((inv) => clearInterval(inv));
-    };
-  }, []);
-
   return (
     <SocketContext.Provider
       value={{
         average: average,
-        roomStatus: status,
-        serverReady: serverReady,
-        user: user,
-        users: users,
-        estimateOptions: roomEstimateOptions,
-        updateRoomOptions,
         changeStatus,
         disconnect,
         estimate,
+        estimateOptions: roomEstimateOptions,
         removeUser,
         reset,
+        roomStatus: status,
+        serverReady: serverReady,
+        setRoomId,
+        updateRoomOptions,
+        user: user,
         userJoin,
+        users: users,
       }}
     >
       {children}

--- a/apps/web/components/provider/SocketProvider.tsx
+++ b/apps/web/components/provider/SocketProvider.tsx
@@ -27,7 +27,6 @@ type Values = {
   reset: () => void;
   roomStatus: Status;
   setRoomId: Dispatch<SetStateAction<string>>;
-  serverReady: boolean;
   updateRoomOptions: (args: RoomOptions) => void;
   user: User | undefined;
   userJoin: (name: string, room: string) => void;
@@ -42,7 +41,6 @@ const initalValues: Values = {
   removeUser: () => undefined,
   reset: () => undefined,
   roomStatus: "estimating",
-  serverReady: false,
   setRoomId: () => undefined,
   updateRoomOptions: () => undefined,
   user: undefined,
@@ -63,7 +61,6 @@ export default function AppProvider({ children }: Props) {
   const [average, setAverage] = useState<Average>(null);
   const [roomEstimateOptions, setRoomEstimateOptions] =
     useState<PossibleEstimates>([]);
-  const [serverReady, setServerReady] = useState(false);
   const [status, setStatus] = useState<Status>("estimating");
   const [user, setUser] = useState<User>();
   const [users, setUsers] = useState<User[]>([]);
@@ -140,7 +137,6 @@ export default function AppProvider({ children }: Props) {
         removeUser,
         reset,
         roomStatus: status,
-        serverReady: serverReady,
         setRoomId,
         updateRoomOptions,
         user: user,

--- a/apps/web/pages/index.tsx
+++ b/apps/web/pages/index.tsx
@@ -1,16 +1,14 @@
 import { nanoid } from "nanoid";
 import { ROOM_STRING_SIZE, USER_NAME_SIZE } from "../types/constants";
-import { SocketContext } from "../components/provider/SocketProvider";
 import { useRouter } from "next/router";
 import Button from "../components/Button";
 import PageLayout from "../components/PageLayout";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import Input from "../components/input";
 import Head from "next/head";
 
 const App = () => {
   const router = useRouter();
-  const { serverReady } = useContext(SocketContext);
   const [roomName, setRoomName] = useState("");
 
   function generateRoomId() {
@@ -39,11 +37,7 @@ const App = () => {
       </header>
 
       <div className="flex flex-col items-center space-y-5">
-        <Button
-          disabled={!serverReady}
-          className="w-full mt-5"
-          onClick={generateRoomId}
-        >
+        <Button className="w-full mt-5" onClick={generateRoomId}>
           Create a Room
         </Button>
 

--- a/apps/web/pages/login/[uuid].tsx
+++ b/apps/web/pages/login/[uuid].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { useSockets } from "../../components/provider/SocketProvider";
 import PageLayout from "../../components/PageLayout";
@@ -10,7 +10,11 @@ import Head from "next/head";
 const Login = () => {
   const router = useRouter();
   const { uuid } = router.query;
-  const { userJoin } = useSockets();
+  const { setRoomId, userJoin } = useSockets();
+
+  useMemo(() => {
+    setRoomId(uuid as string);
+  }, [uuid]);
 
   const [name, setName] = useState("");
 


### PR DESCRIPTION
* removed serverReady check since we have a stable server now,
* remove the socket connection when leaving room (the reason the bug was happening is that there were 2 listeners, and it would set it to the new estimate, then set it to null again)